### PR TITLE
Support wildcard whitelist matcher with ~

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,14 +51,15 @@ Received request {"info":{"phone":"************"}}
 ### Whitelist
 
 Masks all the fields except those whitelisted in the configuration using [JSON Pointer](https://tools.ietf.org/html/rfc6901).
-Only simple values(`string`, `number`, `boolean`) can be whitelisted.
+Only simple values(`string`, `number`, `boolean`) can be whitelisted. Whitelisting array and hash elements can be done using
+wildcard symbol `~`.
 
 #### Configuration
 
 ```yaml
 preprocessors:
   whitelist:
-    pointers: ['/info/phone']
+    pointers: ['/info/phone', '/addresses/~/host']
 ```
 
 #### Usage
@@ -66,7 +67,7 @@ preprocessors:
 ```javascript
 logger = Logasm.build(application_name, logger_config, preprocessors)
 
-input = {password: 'password', info: {phone: '+12055555555'}}
+input = {password: 'password', info: {phone: '+12055555555'}, addresses: [{host: 'example.com', path: 'info'}]}
 
 logger.debug("Received request", input)
 ```
@@ -74,5 +75,5 @@ logger.debug("Received request", input)
 Logger output:
 
 ```
-Received request {password: "********", "info":{"phone":"+12055555555"}}
+Received request {"password": "********", "info":{"phone":"+12055555555"}, "addresses": [{"host": "example.com","path": "****"}]}
 ```

--- a/lib/logasm/preprocessors/whitelist.coffee
+++ b/lib/logasm/preprocessors/whitelist.coffee
@@ -49,10 +49,16 @@ class Whitelist
     , {})
 
   _processValue: (parentPointer, value) ->
-    if parentPointer of @fieldsToInclude
+    if (parentPointer of @fieldsToInclude) || @_matchesWildcard(parentPointer)
       value
     else
       @_mask(value)
+
+  _matchesWildcard: (parentPointer) ->
+    Object.keys(@fieldsToInclude).some((fieldToInclude) ->
+      wildcardMatcher = RegExp("^#{fieldToInclude.replace(/\/~/g, '/[^/]+')}$")
+      parentPointer.match(wildcardMatcher)
+    )
 
   _mask: (value) ->
     if value && _.isFunction(value['toString']) && !_.isBoolean(value)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "logasm",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "author": "Salemove <support@salemove.com>",
   "description": "It's logasmic",
   "repository": {

--- a/test/whitelister_spec.coffee
+++ b/test/whitelister_spec.coffee
@@ -128,3 +128,119 @@ describe 'Whitelist', ->
 
       it 'does not include array', ->
         expect(processedData).to.eql({'field_with_~': 'secret'})
+
+    describe 'wildcard', ->
+      context 'with array elements whitelisted with wildcard', ->
+        pointers.is -> ['/array/~']
+
+        context 'with string array', ->
+          data.is -> {
+            array: ['one', 'two']
+          }
+
+          it 'does not mask array elements', ->
+            expect(processedData).to.eql({
+              array: ['one', 'two']
+            })
+
+        context 'with objects', ->
+          data.is -> {
+            array: [{field: 'secret'}]
+          }
+
+          it 'masks nested array elements', ->
+            expect(processedData).to.eql({
+              array: [{field: '******'}]
+            })
+
+      context 'with fields of array elements whitelisted with wildcard', ->
+        pointers.is -> ['/array/~/field']
+        data.is -> {
+          array: [{field: 'secret', field2: 'secret'}]
+        }
+
+        it 'does not mask the field array elements', ->
+          expect(processedData).to.eql({
+            array: [{field: 'secret', field2: '******'}]
+          })
+
+      context 'with hash fields whitelisted with wildcard', ->
+        pointers.is -> ['/object/~']
+
+        context 'with string array', ->
+          data.is -> {
+            object: {
+              field: 'secret'
+            }
+          }
+
+          it 'does not mask fields', ->
+            expect(processedData).to.eql({
+              object: {
+                field: 'secret'
+              }
+            })
+
+        context 'with nested objects', ->
+          data.is -> {
+            object: {
+              nested: {
+                field: 'secret'
+              }
+            }
+          }
+
+          it 'masks nested objects', ->
+            expect(processedData).to.eql({
+              object: {
+                nested: {
+                  field: '******'
+                }
+              }
+            })
+
+      context 'with fields of nested elements whitelisted with wildcard', ->
+        pointers.is -> ['/object/~/field']
+        data.is -> {
+          object: {
+            nested: {
+              field: 'secret'
+              field2: 'secret'
+            }
+          }
+        }
+
+        it 'does not mask the field array elements', ->
+          expect(processedData).to.eql({
+            object: {
+              nested: {
+                field: 'secret'
+                field2: '******'
+              }
+            }
+          })
+
+    describe 'README example', ->
+      pointers.is -> ['/info/phone', '/addresses/~/host']
+      data.is -> {
+        password: 'password'
+        info: {
+          phone: '+12055555555'
+        }
+        addresses: [{
+          host: 'example.com'
+          path: 'info'
+        }]
+      }
+
+      it 'does not mask the field array elements', ->
+        expect(processedData).to.eql({
+          password: "********"
+          info: {
+            phone: "+12055555555"
+          }
+          addresses: [{
+            host: "example.com"
+            path: "****"
+          }]
+        })


### PR DESCRIPTION
Inspired by salemove/logasm#19 and
salemove/logasm#22. The same functionality is
also required in the node-land.