### PR TITLE
Add timestamp to logstash messages

### DIFF
--- a/lib/logasm/adapters/logstash_adapter.coffee
+++ b/lib/logasm/adapters/logstash_adapter.coffee
@@ -1,6 +1,7 @@
 winston = require('winston')
 _  = require 'underscore'
 LogstashUDP = require('winston-logstash-udp').LogstashUDP
+buildEvent = require('./logstash_adapter/event')
 
 class LogstashAdapter
   constructor:(level, service, {host, port}) ->
@@ -16,13 +17,13 @@ class LogstashAdapter
     @logger.add LogstashUDP, options
 
   log:(level, args) ->
-    args = _.extend({}, args)
-    message = args['message']
+    event = buildEvent(args)
+    message = event['message']
 
     if message
-      delete args['message']
-      @logger.log level, message, args
+      delete event['message']
+      @logger.log level, message, event
     else
-      @logger.log level, args
+      @logger.log level, event
 
 module.exports = LogstashAdapter

--- a/lib/logasm/adapters/logstash_adapter/event.coffee
+++ b/lib/logasm/adapters/logstash_adapter/event.coffee
@@ -1,0 +1,7 @@
+module.exports = (args) ->
+  args = Object.assign({}, args)
+
+  unless args['@timestamp']
+    args['@timestamp'] = new Date().toISOString()
+
+  args

--- a/test/logstash_adapter/event_test.coffee
+++ b/test/logstash_adapter/event_test.coffee
@@ -1,0 +1,9 @@
+buildEvent = require '../../lib/logasm/adapters/logstash_adapter/event'
+
+describe 'buildEvent', ->
+  iso8601Matcher = /^\d{4}(-\d\d(-\d\d(T\d\d:\d\d(:\d\d)?(\.\d+)?(([+-]\d\d:\d\d)|Z)?)?)?)?$/i
+  payload = {x: 'y'}
+
+  it 'adds @timestamp', ->
+    event = buildEvent(payload)
+    expect(event['@timestamp']).to.match(iso8601Matcher)


### PR DESCRIPTION
Otherwise they get their timestamp in logstash which might be off
because of the network delay and processing time.