### PR TITLE
Add serviceName to event

### DIFF
--- a/lib/logasm/adapters/stdout_adapter.js
+++ b/lib/logasm/adapters/stdout_adapter.js
@@ -2,7 +2,8 @@ const winston = require('winston');
 const buildEvent = require('../event');
 
 class StdoutAdapter {
-  constructor(level, _serviceName, options) {
+  constructor(level, serviceName, options) {
+    this.serviceName = serviceName;
     this.logger = new winston.Logger();
     this.logger.add(winston.transports.Console, {
       json: Boolean(options.json),
@@ -15,7 +16,7 @@ class StdoutAdapter {
   }
 
   log(level, args) {
-    const event = buildEvent(args);
+    const event = buildEvent(args, this.serviceName);
     const message = event['message'];
 
     if (message) {

--- a/lib/logasm/event.js
+++ b/lib/logasm/event.js
@@ -1,5 +1,7 @@
-function buildEvent(args) {
+function buildEvent(args, serviceName) {
   event = Object.assign({}, args);
+
+  event['application'] = serviceName;
 
   if (!event['@timestamp']) {
     event['@timestamp'] = new Date().toISOString();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "logasm",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "author": "Salemove TechMovers <techmovers@salemove.com>",
   "description": "It's logasmic",
   "repository": {

--- a/test/event_test.js
+++ b/test/event_test.js
@@ -1,0 +1,10 @@
+const buildEvent = require('../lib/logasm/event');
+
+describe('buildEvent', function() {
+  it('adds application name', () => {
+    const attributes = {};
+    const serviceName = 'service-name';
+    const event = buildEvent(attributes, serviceName);
+    expect(event.application).to.eql(serviceName);
+  });
+});


### PR DESCRIPTION
This allows more easily to identify origin of the logs and also allow
separating logs into multiple indexes in one application.