### PR TITLE
Strict whitelisting

### DIFF
--- a/lib/logasm/preprocessors/strategies/mask_strategy.js
+++ b/lib/logasm/preprocessors/strategies/mask_strategy.js
@@ -1,0 +1,59 @@
+const { isObject } = require('../../object_helpers');
+
+const WILDCARD_SYMBOL = '~';
+const MASKED_VALUE = '*****';
+
+class MaskStrategy {
+  constructor(whitelistedFields) {
+    this.whitelistedFields = whitelistedFields;
+  }
+
+  process(data, path) {
+    if (path == null) { path = []; }
+    
+    if (this._isWhitelistedField(path)) {
+      return this._processData(data, path)
+    } else {
+      return MASKED_VALUE;
+    }
+  }
+
+  _isWhitelistedField(path) {
+    let location = this.whitelistedFields;
+    for (const pointer of Array.from(path)) {
+      location = location[pointer] || location[WILDCARD_SYMBOL];
+      if (!location) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  _processData(data, path) {
+    if (Array.isArray(data)) {
+      return this._processArray(data, path);
+    } else if (isObject(data)) {
+      return this._processObject(data, path);
+    } else {
+      return data;
+    }
+  }
+
+  _processArray(array, path) {
+    return array.reduce((mem, value, index) => {
+      const processedValue = this.process(value, path.concat([index]));
+      mem.push(processedValue);
+      return mem;
+    }, []);
+  }
+
+  _processObject(obj, path) {
+    return Object.entries(obj).reduce((mem, [key, value]) => {
+      const processedValue = this.process(value, path.concat([key]));
+      mem[key] = processedValue;
+      return mem;
+    }, {});
+  }
+}
+
+module.exports = MaskStrategy;

--- a/lib/logasm/preprocessors/strategies/prune_strategy.js
+++ b/lib/logasm/preprocessors/strategies/prune_strategy.js
@@ -1,0 +1,63 @@
+const { isObject } = require('../../object_helpers');
+
+const WILDCARD_SYMBOL = '~';
+const MASKED_VALUE = '*****';
+
+class PruneStrategy {
+  constructor(whitelistedFields) {
+    this.whitelistedFields = whitelistedFields;
+  }
+
+  process(data, path) {
+    if (path == null) { path = []; }
+    
+    if (this._isWhitelistedField(path)) {
+      return this._processData(data, path)
+    } else {
+      return null;
+    }
+  }
+
+  _isWhitelistedField(path) {
+    let location = this.whitelistedFields;
+    for (const pointer of Array.from(path)) {
+      location = location[pointer] || location[WILDCARD_SYMBOL];
+      if (!location) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  _processData(data, path) {
+    if (Array.isArray(data)) {
+      return this._processArray(data, path);
+    } else if (isObject(data)) {
+      return this._processObject(data, path);
+    } else {
+      return data;
+    }
+  }
+
+  _processArray(array, path) {
+    return array.reduce((mem, value, index) => {
+      if (this._isWhitelistedField(path.concat([index]))) {
+        const processedValue = this.process(value, path.concat([index]));
+        mem.push(processedValue);
+      }
+      return mem;
+    }, []);
+  }
+
+  _processObject(obj, path) {
+    return Object.entries(obj).reduce((mem, [key, value]) => {
+      if (this._isWhitelistedField(path.concat([key]))) {
+        const processedValue = this.process(value, path.concat([key]));
+        mem[key] = processedValue;
+      }
+      return mem;
+    }, {});
+  }
+}
+
+module.exports = PruneStrategy;

--- a/lib/logasm/preprocessors/whitelist.js
+++ b/lib/logasm/preprocessors/whitelist.js
@@ -1,4 +1,5 @@
-const { isObject } = require('../object_helpers');
+const MaskStrategy = require('./strategies/mask_strategy')
+const PruneStrategy = require('./strategies/prune_strategy')
 
 function addToWhitelist(whitelist, pointerPaths) {
   const path = pointerPaths[0]
@@ -11,14 +12,16 @@ function addToWhitelist(whitelist, pointerPaths) {
   }
 };
 
-const MASKED_VALUE = '*****';
-const WILDCARD_SYMBOL = '~';
+const PRUNE_ACTION = 'prune';
+const MASK_ACTION = 'mask';
+const DEFAULT_ACTION = MASK_ACTION;
 
 class Whitelist {
   constructor(config) {
     // Winston logs the first argument as `message` field. Making sure this is
     // always whitelisted.
     const pointers = (config.pointers || []).concat(['/message']);
+    const action = config.action || DEFAULT_ACTION;
 
     this.whitelistedFields = {};
 
@@ -27,51 +30,22 @@ class Whitelist {
       const pointerPaths = pointer.split('/').splice(1);
       addToWhitelist(this.whitelistedFields, pointerPaths);
     }
+
+    if (action === MASK_ACTION) {
+     this.strategy = new MaskStrategy(this.whitelistedFields);
+    } else {
+      this.strategy = new PruneStrategy(this.whitelistedFields);
+    }
   }
 
   process(data, path) {
-    if (path == null) { path = []; }
-    if (Array.isArray(data)) {
-      return this._processArray(data, path);
-    } else if (isObject(data)) {
-      return this._processObject(data, path);
-    } else {
-      return this._processValue(data, path);
-    }
+    return this.strategy.process(data, path);
   }
 
   _validatePointer(pointer) {
     if (pointer.charAt(pointer.length - 1) === '/') {
       throw Error('Pointer should not contain trailing slash');
     }
-  }
-
-  _processArray(array, path) {
-    return array.reduce((mem, value, index) => {
-      const processedValue = this.process(value, path.concat([index]));
-      mem.push(processedValue);
-      return mem;
-    }, []);
-  }
-
-  _processObject(obj, path) {
-    return Object.entries(obj).reduce((mem, [key, value]) => {
-      const processedValue = this.process(value, path.concat([key]));
-      mem[key] = processedValue;
-      return mem;
-    }, {});
-  }
-
-  _processValue(value, path) {
-    let location = this.whitelistedFields;
-    for (const pointer of Array.from(path)) {
-      location = location[pointer] || location[WILDCARD_SYMBOL];
-      if (!location) {
-        return MASKED_VALUE;
-      }
-    }
-
-    return value;
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "logasm",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "author": "Salemove TechMovers <techmovers@salemove.com>",
   "description": "It's logasmic",
   "repository": {

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,5 +1,4 @@
 --require test/test_helper
 --reporter spec
 --ui bdd
---compilers coffee:coffee-script/register
 --recursive

--- a/test/whitelist_performance_test.js
+++ b/test/whitelist_performance_test.js
@@ -14,14 +14,32 @@ let buildPointers = function(exactPointersCount, wildcardPointersCount) {
   return pointers;
 };
 
-describe('Whitelist Performance', () =>
+let action = memo().is(() => '');
 
+describe('Whitelist Performance', function() {
+  context('with prune strategy', () => {
+    action.is(() => 'prune');
+
+    testPerformance();
+  });
+
+  context('with mask strategy', () => {
+    action.is(() => 'mask');
+
+    testPerformance();
+  });
+});
+
+function testPerformance() {
   it('processes 10K statements for 100 exact and wildcard pointers with less than 100 milliseconds', function() {
     let exactPointersCount = 100;
     let wildcardPointersCount = 100;
     let messagesToProcess = 10000;
 
-    let whitelist = new Whitelist({pointers: buildPointers(exactPointersCount, wildcardPointersCount)});
+    let whitelist = new Whitelist({
+      pointers: buildPointers(exactPointersCount, wildcardPointersCount),
+      action: action()
+    });
 
     let startTimestamp = new Date();
 
@@ -41,4 +59,4 @@ describe('Whitelist Performance', () =>
 
     expect(duration).to.be.at.most(100);
   })
-);
+}


### PR DESCRIPTION
Change whitelisting approach. For masking do not include child nodes if
the parent node itself is not whitelisted. Added prune action which only
includes a field if it is whitelisted. Ported from ruby logasm project.