### PR TITLE
Map error stack to `stack`

### DIFF
--- a/lib/logasm.js
+++ b/lib/logasm.js
@@ -75,15 +75,15 @@ class Logasm {
       let data = {};
 
       if (metadata instanceof Error) {
-        data['error'] = metadata.toString();
-        if (metadata.stack) { data['error.stack_trace'] = metadata.stack; }
+        data['error'] = { message: metadata.toString() };
+        if (metadata.stack) { data['error']['stack'] = metadata.stack; };
       } else {
         Object.assign(data, metadata);
       }
 
       if (message instanceof Error) {
-        data['error'] = message.toString();
-        if (message.stack) { data['error.stack_trace'] = message.stack; }
+        data['error'] = { message: message.toString() };
+        if (message.stack) { data['error']['stack'] = message.stack; };
       }
 
       data['message'] = message;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "logasm",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "author": "Salemove TechMovers <techmovers@salemove.com>",
   "description": "It's logasmic",
   "repository": {

--- a/test/logasm_test.js
+++ b/test/logasm_test.js
@@ -71,5 +71,13 @@ describe('Logasm', function() {
 
       expect(result).to.eql({message: 'test message', test: 'data', more: 'testing'});
     });
+
+    it('parses Error', function() {
+      let result = logasm.parseLogData(new Error('test message'));
+
+      expect(result.message).to.match(/Error: test message/);
+      expect(result.error.message).to.eq('Error: test message');
+      expect(result.error.stack).to.match(/Error: test message/);
+    });
   });
 });


### PR DESCRIPTION
`error.stack_trace` causes log parse errors.
error is now an object with keys `message` and `stack`. 

Error logging would then look like this 
```
2018-03-12T12:45:47.493Z - error: {} message=ReferenceError: params is not defined, stack=ReferenceError: params is not defined
  at MessageHub.reestablishOrRegisterVisitor (/Users/tonis.kasekamp/salemove/message-hub/lib/message_hub.coffee:527:20)
  ...
```